### PR TITLE
Fix decorator generation

### DIFF
--- a/infobip-typescript-generator-extension-annotation-processor-showcase/pom.xml
+++ b/infobip-typescript-generator-extension-annotation-processor-showcase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.infobip</groupId>
         <artifactId>infobip-typescript-generator-extension</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>infobip-typescript-generator-extension-annotation-processor-showcase</artifactId>

--- a/infobip-typescript-generator-extension-annotation-processor/pom.xml
+++ b/infobip-typescript-generator-extension-annotation-processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.infobip</groupId>
         <artifactId>infobip-typescript-generator-extension</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>infobip-typescript-generator-extension-annotation-processor</artifactId>

--- a/infobip-typescript-generator-extension-api/pom.xml
+++ b/infobip-typescript-generator-extension-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.infobip</groupId>
         <artifactId>infobip-typescript-generator-extension</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>infobip-typescript-generator-extension-api</artifactId>

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -90,11 +90,11 @@ public class ClassTransformerDecoratorExtension extends Extension {
     }
 
     private boolean isHierarchicalDecoratorNeeded(JsonTypeResolver resolver, Class<?> type) {
-        return resolver instanceof CompositeJsonTypeResolver<?> && !isHierarchyLeaf(type);
+        return resolver instanceof CompositeJsonTypeResolver<?> && isHierarchyRoot(type);
     }
 
-    private boolean isHierarchyLeaf(Class<?> type) {
-        return Modifier.isFinal(type.getModifiers());
+    private boolean isHierarchyRoot(Class<?> type) {
+        return Modifier.isAbstract(type.getModifiers()) || type.isInterface();
     }
 
     private List<TsDecorator> getHierarchyDecorators(SymbolTable symbolTable,

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -22,7 +22,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
 
     @Override
     public EmitterExtensionFeatures getFeatures() {
-        final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
+        EmitterExtensionFeatures features = new EmitterExtensionFeatures();
         features.generatesRuntimeCode = true;
         return features;
     }
@@ -71,7 +71,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
             typeToDecorate = type.getComponentType();
         }
 
-        final Optional<Class<?>> typeArgument = parameterizedTypeClasses.getTypeArgument();
+        Optional<Class<?>> typeArgument = parameterizedTypeClasses.getTypeArgument();
         if (Collection.class.isAssignableFrom(type) && typeArgument.isPresent()) {
             typeToDecorate = typeArgument.get();
         }
@@ -123,7 +123,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
         TsArrowFunction emptyToTypeName = new TsArrowFunction(Collections.emptyList(), new TsTypeReferenceExpression(
                 new TsType.ReferenceType(new Symbol(type.getSimpleName()))));
 
-        final Stream<TsDecorator> typeDecoratorStream = shouldNotBeDecorated(type) ?
+        Stream<TsDecorator> typeDecoratorStream = shouldNotBeDecorated(type) ?
                 Stream.empty() :
                 Stream.of(new TsDecorator(TYPE, Collections.singletonList(emptyToTypeName)));
 
@@ -184,9 +184,9 @@ public class ClassTransformerDecoratorExtension extends Extension {
     }
 
     private Optional<Class<?>> getTypeArgument(Field field) {
-        final Type genericType = field.getGenericType();
+        Type genericType = field.getGenericType();
         if (genericType instanceof ParameterizedType) {
-            final Type[] actualTypeArguments = ((ParameterizedType) genericType).getActualTypeArguments();
+            Type[] actualTypeArguments = ((ParameterizedType) genericType).getActualTypeArguments();
             if (actualTypeArguments.length != 0 && actualTypeArguments[0] instanceof Class) {
                 return Optional.of((Class<?>) actualTypeArguments[0]);
             }

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -85,11 +85,6 @@ public class ClassTransformerDecoratorExtension extends Extension {
                                             TsBeanModel model,
                                             TsPropertyModel tsPropertyModel,
                                             Class<?> type) {
-        // TODO: Fix symbolTable issue for this type
-        if ("ImagemapAction".equals(type.getSimpleName())) {
-            return tsPropertyModel.getDecorators();
-        }
-
         return factory.create(type)
                       .filter(resolver -> resolver instanceof CompositeJsonTypeResolver<?>)
                       .filter(resolver -> !Modifier.isFinal(type.getModifiers()))

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -124,7 +124,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
     }
 
     private boolean isBuiltIn(Class<?> type) {
-        return "java.lang".equals(type.getPackage().getName());
+        return "java.lang".equals(Optional.ofNullable(type.getPackage()).map(Package::getName).orElse(""));
     }
 
     private void appendToParentToChildren(Class<?> key, Stream<? extends Class<?>> value) {

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -83,11 +83,18 @@ public class ClassTransformerDecoratorExtension extends Extension {
                                             TsPropertyModel tsPropertyModel,
                                             Class<?> type) {
         return factory.create(type)
-                      .filter(resolver -> resolver instanceof CompositeJsonTypeResolver<?>)
-                      .filter(resolver -> !Modifier.isFinal(type.getModifiers()))
+                      .filter(resolver -> isHierarchicalDecoratorNeeded(resolver, type))
                       .map(resolver -> (CompositeJsonTypeResolver<?>) resolver)
                       .map(resolver -> getHierarchyDecorators(symbolTable, model, tsPropertyModel, resolver))
                       .orElseGet(() -> getNonHierarchyDecorators(tsPropertyModel, type));
+    }
+
+    private boolean isHierarchicalDecoratorNeeded(JsonTypeResolver resolver, Class<?> type) {
+        return resolver instanceof CompositeJsonTypeResolver<?> && !isHierarchyLeaf(type);
+    }
+
+    private boolean isHierarchyLeaf(Class<?> type) {
+        return Modifier.isFinal(type.getModifiers());
     }
 
     private List<TsDecorator> getHierarchyDecorators(SymbolTable symbolTable,

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -86,7 +86,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
                       .filter(resolver -> isHierarchicalDecoratorNeeded(resolver, type))
                       .map(resolver -> (CompositeJsonTypeResolver<?>) resolver)
                       .map(resolver -> getHierarchyDecorators(symbolTable, model, tsPropertyModel, resolver))
-                      .orElseGet(() -> getNonHierarchyDecorators(tsPropertyModel, type));
+                      .orElseGet(() -> getNonHierarchyDecorators(symbolTable, tsPropertyModel, type));
     }
 
     private boolean isHierarchicalDecoratorNeeded(JsonTypeResolver resolver, Class<?> type) {
@@ -117,11 +117,12 @@ public class ClassTransformerDecoratorExtension extends Extension {
                      .collect(Collectors.toList());
     }
 
-    private List<TsDecorator> getNonHierarchyDecorators(TsPropertyModel tsPropertyModel,
+    private List<TsDecorator> getNonHierarchyDecorators(SymbolTable symbolTable,
+                                                        TsPropertyModel tsPropertyModel,
                                                         Class<?> type) {
 
         TsArrowFunction emptyToTypeName = new TsArrowFunction(Collections.emptyList(), new TsTypeReferenceExpression(
-                new TsType.ReferenceType(new Symbol(type.getSimpleName()))));
+                new TsType.ReferenceType(symbolTable.getSymbol(type))));
 
         Stream<TsDecorator> typeDecoratorStream = shouldNotBeDecorated(type) ?
                 Stream.empty() :

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -148,14 +148,14 @@ public class ClassTransformerDecoratorExtension extends Extension {
     }
 
     private boolean shouldNotBeDecorated(Class<?> type) {
-        return isBuiltIn(type) || isTsTypeResolutionUnsupported(type);
+        return isBuiltInType(type) || isTsTypeResolutionUnsupported(type);
     }
 
     private boolean isTsTypeResolutionUnsupported(Class<?> type) {
         return type.isEnum() || PresentPropertyJsonHierarchy.class.isAssignableFrom(type);
     }
 
-    private boolean isBuiltIn(Class<?> type) {
+    private boolean isBuiltInType(Class<?> type) {
         return Optional.ofNullable(type.getPackage()).map(Package::getName).orElse("").startsWith("java");
     }
 

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -85,8 +85,14 @@ public class ClassTransformerDecoratorExtension extends Extension {
                                             TsBeanModel model,
                                             TsPropertyModel tsPropertyModel,
                                             Class<?> type) {
+        // TODO: Fix symbolTable issue for this type
+        if ("ImagemapAction".equals(type.getSimpleName())) {
+            return tsPropertyModel.getDecorators();
+        }
+
         return factory.create(type)
                       .filter(resolver -> resolver instanceof CompositeJsonTypeResolver<?>)
+                      .filter(resolver -> !Modifier.isFinal(type.getModifiers()))
                       .map(resolver -> (CompositeJsonTypeResolver<?>) resolver)
                       .map(resolver -> getHierarchyDecorators(symbolTable, model, tsPropertyModel, resolver))
                       .orElseGet(() -> getNonHierarchyDecorators(tsPropertyModel, type));

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtension.java
@@ -180,7 +180,7 @@ public class ClassTransformerDecoratorExtension extends Extension {
         final Type genericType = field.getGenericType();
         if (genericType instanceof ParameterizedType) {
             final Type[] actualTypeArguments = ((ParameterizedType) genericType).getActualTypeArguments();
-            if (actualTypeArguments.length != 0) {
+            if (actualTypeArguments.length != 0 && actualTypeArguments[0] instanceof Class) {
                 return Optional.of((Class<?>) actualTypeArguments[0]);
             }
         }

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ParameterizedTypeClasses.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/transformer/ParameterizedTypeClasses.java
@@ -1,0 +1,22 @@
+package com.infobip.typescript.transformer;
+
+import java.util.Optional;
+
+class ParameterizedTypeClasses {
+
+    private final Class<?> type;
+    private final Optional<Class<?>> typeArgument;
+
+    ParameterizedTypeClasses(Class<?> type, Optional<Class<?>> typeArgument) {
+        this.type = type;
+        this.typeArgument = typeArgument;
+    }
+
+    Class<?> getType() {
+        return type;
+    }
+
+    Optional<Class<?>> getTypeArgument() {
+        return typeArgument;
+    }
+}

--- a/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/validation/ClassValidatorDecoratorExtension.java
+++ b/infobip-typescript-generator-extension-api/src/main/java/com/infobip/typescript/validation/ClassValidatorDecoratorExtension.java
@@ -24,6 +24,7 @@ public class ClassValidatorDecoratorExtension extends Extension implements TypeS
     static {
         DEFAULT_VALIDATIONS = Stream.of("@ValidateNested(",
                                         "@IsDefined(",
+                                        "@IsOptional(",
                                         "@IsNotEmpty(",
                                         "@MaxLength(",
                                         "@MinLength(",
@@ -113,10 +114,10 @@ public class ClassValidatorDecoratorExtension extends Extension implements TypeS
 
         if (typeScript.contains(COMMON_VALIDATION_MESSAGES_CLASS_NAME)) {
             String commonValidationMessagesImport = "import { CommonValidationMessages } from './CommonValidationMessages';";
-            return Arrays.asList(validationImport, commonValidationMessagesImport).stream();
+            return Stream.of(validationImport, commonValidationMessagesImport);
         }
 
-        return Collections.singletonList(validationImport).stream();
+        return Stream.of(validationImport);
     }
 
     private Stream<String> resolve(List<TSCustomDecorator> tsCustomDecorators) {

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -1,7 +1,6 @@
 package com.infobip.typescript.transformer;
 
-import com.infobip.jackson.SimpleJsonHierarchy;
-import com.infobip.jackson.TypeProvider;
+import com.infobip.jackson.*;
 import com.infobip.typescript.TestBase;
 import cz.habarta.typescript.generator.Input;
 import lombok.*;
@@ -20,19 +19,30 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
 
     @Test
     void shouldDecorateNonHierarchiesWithType() {
-        String actual = whenGenerate(Input.from(Root.class, Leaf.class));
+        String actual = whenGenerate(Input.from(Root.class, Leaf.class, Unsupported.class));
 
         then(fixNewlines(actual)).isEqualTo(
                 "" +
                         "import { Type } from 'class-transformer';\n" +
                         "\n" +
+                        "export enum Enumeration {\n" +
+                        "    VALUE = \"VALUE\",\n" +
+                        "}\n" +
+                        "\n" +
                         "export class Leaf {\n" +
+                        "}\n" +
+                        "\n" +
+                        "export interface Unsupported {\n" +
                         "}\n" +
                         "\n" +
                         "export class Root {\n" +
                         "    @Type(() => Leaf)\n" +
                         "    leaf: Leaf;\n" +
                         "    leafOfBuiltInType: string;\n" +
+                        "    @Type(() => Leaf)\n" +
+                        "    leafArray: Leaf[];\n" +
+                        "    enumeration: Enumeration;\n" +
+                        "    unsupported: Unsupported;\n" +
                         "}");
 
     }
@@ -41,10 +51,30 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     static class Root {
         Leaf leaf;
         String leafOfBuiltInType;
+        Leaf[] leafArray;
+        Enumeration enumeration;
+        Unsupported unsupported;
     }
 
     @Value
     static class Leaf {
+    }
+
+    enum Enumeration {
+        VALUE
+    }
+
+
+    interface Unsupported extends PresentPropertyJsonHierarchy<UnsupportedType> { }
+
+    static class UnsupportedImpl implements Unsupported { }
+
+    @Getter
+    @AllArgsConstructor
+    enum UnsupportedType implements TypeProvider {
+        VALUE(UnsupportedImpl.class);
+
+        private final Class<? extends Unsupported> type;
     }
 
     @Test

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -44,11 +44,11 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                         "    enumeration: Enumeration;\n" +
                         "    unsupported: Unsupported;\n" +
                         "}");
-
     }
 
     @Value
     static class Root {
+
         Leaf leaf;
         String leafOfBuiltInType;
         Leaf[] leafArray;
@@ -58,16 +58,20 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
 
     @Value
     static class Leaf {
+
     }
 
     enum Enumeration {
         VALUE
     }
 
+    interface Unsupported extends PresentPropertyJsonHierarchy<UnsupportedType> {
 
-    interface Unsupported extends PresentPropertyJsonHierarchy<UnsupportedType> { }
+    }
 
-    static class UnsupportedImpl implements Unsupported { }
+    static class UnsupportedImpl implements Unsupported {
+
+    }
 
     @Getter
     @AllArgsConstructor

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -7,7 +7,6 @@ import cz.habarta.typescript.generator.Input;
 import lombok.*;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -20,7 +19,34 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     }
 
     @Test
-    void shouldDecorate() {
+    void shouldDecorateNonHierarchiesWithType() {
+        String actual = whenGenerate(Input.from(Root.class, Leaf.class));
+
+        then(fixNewlines(actual)).isEqualTo(
+                "" +
+                        "import { Type } from 'class-transformer';\n" +
+                        "\n" +
+                        "export class Leaf {\n" +
+                        "}\n" +
+                        "\n" +
+                        "export class Root {\n" +
+                        "    @Type(() => Leaf)\n" +
+                        "    leaf: Leaf;\n" +
+                        "}");
+
+    }
+
+    @Value
+    static class Root {
+        Leaf leaf;
+    }
+
+    @Value
+    static class Leaf {
+    }
+
+    @Test
+    void shouldDecorateHierarchiesWithType() {
 
         // when
         String actual = whenGenerate(Input.from(FirstHierarchyRoot.class,
@@ -31,61 +57,65 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                                                 NestedHierarchyLeaf.class));
 
         // then
-        then(actual.replace("\r\n", "\n")).isEqualTo(
-                "\n" +
-                "import { Type } from 'class-transformer';\n" +
-                "\n" +
-                "export enum FirstHierarchyType {\n" +
-                "    LEAF = \"LEAF\",\n" +
-                "}\n" +
-                "\n" +
-                "export enum SecondHierarchyType {\n" +
-                "    LEAF = \"LEAF\",\n" +
-                "}\n" +
-                "\n" +
-                "export enum NestedHierarchyType {\n" +
-                "    LEAF = \"LEAF\",\n" +
-                "}\n" +
-                "\n" +
-                "export interface FirstHierarchyRoot {\n" +
-                "    type: FirstHierarchyType;\n" +
-                "}\n" +
-                "\n" +
-                "export interface SecondHierarchyRoot {\n" +
-                "    type: SecondHierarchyType;\n" +
-                "}\n" +
-                "\n" +
-                "export interface NestedHierarchyRoot {\n" +
-                "    type: NestedHierarchyType;\n" +
-                "}\n" +
-                "\n" +
-                "export class NestedHierarchyLeaf implements NestedHierarchyRoot {\n" +
-                "    type: NestedHierarchyType;\n" +
-                "}\n" +
-                "\n" +
-                "export class FirstHierarchyLeaf implements FirstHierarchyRoot {\n" +
-                "    type: FirstHierarchyType;\n" +
-                "    @Type(() => Object, {\n" +
-                "        discriminator: {\n" +
-                "            property: \"type\", subTypes: [\n" +
-                "                { value: NestedHierarchyLeaf, name: NestedHierarchyType.LEAF }\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    })\n" +
-                "    nested: NestedHierarchyRoot;\n" +
-                "}\n" +
-                "\n" +
-                "export class SecondHierarchyLeaf implements SecondHierarchyRoot {\n" +
-                "    type: SecondHierarchyType;\n" +
-                "    @Type(() => Object, {\n" +
-                "        discriminator: {\n" +
-                "            property: \"type\", subTypes: [\n" +
-                "                { value: NestedHierarchyLeaf, name: NestedHierarchyType.LEAF }\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    })\n" +
-                "    nested: NestedHierarchyRoot;\n" +
-                "}\n");
+        then(fixNewlines(actual)).isEqualTo(
+                "" +
+                        "import { Type } from 'class-transformer';\n" +
+                        "\n" +
+                        "export enum FirstHierarchyType {\n" +
+                        "    LEAF = \"LEAF\",\n" +
+                        "}\n" +
+                        "\n" +
+                        "export enum SecondHierarchyType {\n" +
+                        "    LEAF = \"LEAF\",\n" +
+                        "}\n" +
+                        "\n" +
+                        "export enum NestedHierarchyType {\n" +
+                        "    LEAF = \"LEAF\",\n" +
+                        "}\n" +
+                        "\n" +
+                        "export interface FirstHierarchyRoot {\n" +
+                        "    type: FirstHierarchyType;\n" +
+                        "}\n" +
+                        "\n" +
+                        "export interface SecondHierarchyRoot {\n" +
+                        "    type: SecondHierarchyType;\n" +
+                        "}\n" +
+                        "\n" +
+                        "export interface NestedHierarchyRoot {\n" +
+                        "    type: NestedHierarchyType;\n" +
+                        "}\n" +
+                        "\n" +
+                        "export class NestedHierarchyLeaf implements NestedHierarchyRoot {\n" +
+                        "    type: NestedHierarchyType;\n" +
+                        "}\n" +
+                        "\n" +
+                        "export class FirstHierarchyLeaf implements FirstHierarchyRoot {\n" +
+                        "    type: FirstHierarchyType;\n" +
+                        "    @Type(() => Object, {\n" +
+                        "        discriminator: {\n" +
+                        "            property: \"type\", subTypes: [\n" +
+                        "                { value: NestedHierarchyLeaf, name: NestedHierarchyType.LEAF }\n" +
+                        "            ]\n" +
+                        "        }\n" +
+                        "    })\n" +
+                        "    nested: NestedHierarchyRoot;\n" +
+                        "}\n" +
+                        "\n" +
+                        "export class SecondHierarchyLeaf implements SecondHierarchyRoot {\n" +
+                        "    type: SecondHierarchyType;\n" +
+                        "    @Type(() => Object, {\n" +
+                        "        discriminator: {\n" +
+                        "            property: \"type\", subTypes: [\n" +
+                        "                { value: NestedHierarchyLeaf, name: NestedHierarchyType.LEAF }\n" +
+                        "            ]\n" +
+                        "        }\n" +
+                        "    })\n" +
+                        "    nested: NestedHierarchyRoot;\n" +
+                        "}");
+    }
+
+    private String fixNewlines(String actual) {
+        return actual.trim().replace("\r\n", "\n");
     }
 
     @Getter
@@ -127,7 +157,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     @Value
     static class FirstHierarchyLeaf implements FirstHierarchyRoot {
 
-        private final NestedHierarchyRoot nested;
+        NestedHierarchyRoot nested;
 
         @Override
         public FirstHierarchyType getType() {
@@ -138,7 +168,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     @Value
     static class SecondHierarchyLeaf implements SecondHierarchyRoot {
 
-        private final NestedHierarchyRoot nested;
+        NestedHierarchyRoot nested;
 
         @Override
         public SecondHierarchyType getType() {

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -32,6 +32,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                         "export class Root {\n" +
                         "    @Type(() => Leaf)\n" +
                         "    leaf: Leaf;\n" +
+                        "    leafOfBuiltInType: string;\n" +
                         "}");
 
     }
@@ -39,6 +40,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     @Value
     static class Root {
         Leaf leaf;
+        String leafOfBuiltInType;
     }
 
     @Value

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -150,7 +150,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                         "            ]\n" +
                         "        }\n" +
                         "    })\n" +
-                        "    nested: NestedHierarchyRoot;\n" +
+                        "    nested: NestedHierarchyRoot[];\n" +
                         "}");
     }
 
@@ -208,7 +208,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     @Value
     static class SecondHierarchyLeaf implements SecondHierarchyRoot {
 
-        NestedHierarchyRoot nested;
+        NestedHierarchyRoot[] nested;
 
         @Override
         public SecondHierarchyType getType() {

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -7,6 +7,7 @@ import lombok.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -43,6 +44,8 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                         "    leafArray: Leaf[];\n" +
                         "    enumeration: Enumeration;\n" +
                         "    unsupported: Unsupported;\n" +
+                        "    @Type(() => Leaf)\n" +
+                        "    listOfLeaves: Leaf[];\n" +
                         "}");
     }
 
@@ -54,6 +57,7 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
         Leaf[] leafArray;
         Enumeration enumeration;
         Unsupported unsupported;
+        List<Leaf> listOfLeaves;
     }
 
     @Value

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/transformer/ClassTransformerDecoratorExtensionTest.java
@@ -150,7 +150,15 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
                         "            ]\n" +
                         "        }\n" +
                         "    })\n" +
-                        "    nested: NestedHierarchyRoot[];\n" +
+                        "    nestedArray: NestedHierarchyRoot[];\n" +
+                        "    @Type(() => Object, {\n" +
+                        "        discriminator: {\n" +
+                        "            property: \"type\", subTypes: [\n" +
+                        "                { value: NestedHierarchyLeaf, name: NestedHierarchyType.LEAF }\n" +
+                        "            ]\n" +
+                        "        }\n" +
+                        "    })\n" +
+                        "    nestedList: NestedHierarchyRoot[];\n" +
                         "}");
     }
 
@@ -208,7 +216,8 @@ class ClassTransformerDecoratorExtensionTest extends TestBase {
     @Value
     static class SecondHierarchyLeaf implements SecondHierarchyRoot {
 
-        NestedHierarchyRoot[] nested;
+        NestedHierarchyRoot[] nestedArray;
+        List<NestedHierarchyRoot> nestedList;
 
         @Override
         public SecondHierarchyType getType() {

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ClassValidatorDecoratorTestBase.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ClassValidatorDecoratorTestBase.java
@@ -9,13 +9,10 @@ import com.infobip.typescript.custom.validation.extractor.TSCustomDecorator;
 
 abstract class ClassValidatorDecoratorTestBase extends TestBase {
 
-    private static final String IMPORT_COMMON_VALIDATION_MESSAGES = "import { CommonValidationMessages } from 'infobip-typescript-generator-common'";
-    private static final String IMPORT_CLASS_VALIDATOR = "import { ValidateNested, IsDefined, IsOptional, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator'";
-    protected static final String IMPORTS = IMPORT_COMMON_VALIDATION_MESSAGES + ";\n" + IMPORT_CLASS_VALIDATOR + ";\n";
-
     ClassValidatorDecoratorTestBase() {
         super(new ClassValidatorDecoratorExtension(),
-              Arrays.asList(IMPORT_COMMON_VALIDATION_MESSAGES, IMPORT_CLASS_VALIDATOR));
+              Arrays.asList("import { CommonValidationMessages } from 'infobip-typescript-generator-common'",
+                            "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator'"));
     }
 
     ClassValidatorDecoratorTestBase(List<TSCustomDecorator> tsCustomDecorators,

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ClassValidatorDecoratorTestBase.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ClassValidatorDecoratorTestBase.java
@@ -9,10 +9,13 @@ import com.infobip.typescript.custom.validation.extractor.TSCustomDecorator;
 
 abstract class ClassValidatorDecoratorTestBase extends TestBase {
 
+    private static final String IMPORT_COMMON_VALIDATION_MESSAGES = "import { CommonValidationMessages } from 'infobip-typescript-generator-common'";
+    private static final String IMPORT_CLASS_VALIDATOR = "import { ValidateNested, IsDefined, IsOptional, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator'";
+    protected static final String IMPORTS = IMPORT_COMMON_VALIDATION_MESSAGES + ";\n" + IMPORT_CLASS_VALIDATOR + ";\n";
+
     ClassValidatorDecoratorTestBase() {
         super(new ClassValidatorDecoratorExtension(),
-              Arrays.asList("import { CommonValidationMessages } from 'infobip-typescript-generator-common'",
-                            "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator'"));
+              Arrays.asList(IMPORT_COMMON_VALIDATION_MESSAGES, IMPORT_CLASS_VALIDATOR));
     }
 
     ClassValidatorDecoratorTestBase(List<TSCustomDecorator> tsCustomDecorators,

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MaxToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MaxToTsClassValidatorDecoratorConverterTest.java
@@ -17,7 +17,10 @@ class MaxToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
         String actual = whenGenerate(Input.from(Foo.class));
 
         // then
-        then(actual).isEqualTo("\n" + IMPORTS + "\n" +
+        then(actual).isEqualTo("\n" +
+                               "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                               "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                               "\n" +
                                "export class Foo {\n" +
                                "    @Max(1, { message: CommonValidationMessages.Max(1) })\n" +
                                "    bar: any;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MaxToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MaxToTsClassValidatorDecoratorConverterTest.java
@@ -17,10 +17,7 @@ class MaxToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
         String actual = whenGenerate(Input.from(Foo.class));
 
         // then
-        then(actual).isEqualTo("\n" +
-                               "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                               "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                               "\n" +
+        then(actual).isEqualTo("\n" + IMPORTS + "\n" +
                                "export class Foo {\n" +
                                "    @Max(1, { message: CommonValidationMessages.Max(1) })\n" +
                                "    bar: any;\n" +
@@ -31,6 +28,6 @@ class MaxToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
     static class Foo {
 
         @Max(value = 1)
-        private final Object bar;
+        Object bar;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MinToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MinToTsClassValidatorDecoratorConverterTest.java
@@ -18,10 +18,7 @@ class MinToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @Min(1, { message: CommonValidationMessages.Min(1) })\n" +
                 "    bar: any;\n" +
@@ -32,6 +29,6 @@ class MinToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
     static class Foo {
 
         @Min(1)
-        private final Object bar;
+        Object bar;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MinToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/MinToTsClassValidatorDecoratorConverterTest.java
@@ -18,7 +18,10 @@ class MinToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorato
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @Min(1, { message: CommonValidationMessages.Min(1) })\n" +
                 "    bar: any;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotBlankToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotBlankToTsClassValidatorDecoratorConverterTest.java
@@ -18,10 +18,7 @@ class NotBlankToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @IsNotEmpty({ message: CommonValidationMessages.IsNotEmpty })\n" +
                 "    bar: string;\n" +
@@ -32,6 +29,6 @@ class NotBlankToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
     static class Foo {
 
         @NotBlank
-        private final String bar;
+        String bar;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotBlankToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotBlankToTsClassValidatorDecoratorConverterTest.java
@@ -18,7 +18,10 @@ class NotBlankToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @IsNotEmpty({ message: CommonValidationMessages.IsNotEmpty })\n" +
                 "    bar: string;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotEmptyToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotEmptyToTsClassValidatorDecoratorConverterTest.java
@@ -18,10 +18,7 @@ class NotEmptyToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @IsNotEmpty({ message: CommonValidationMessages.IsNotEmpty })\n" +
                 "    bar: string;\n" +
@@ -32,6 +29,6 @@ class NotEmptyToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
     static class Foo {
 
         @NotEmpty
-        private final String bar;
+        String bar;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotEmptyToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotEmptyToTsClassValidatorDecoratorConverterTest.java
@@ -18,7 +18,10 @@ class NotEmptyToTsClassValidatorDecoratorConverterTest extends ClassValidatorDec
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @IsNotEmpty({ message: CommonValidationMessages.IsNotEmpty })\n" +
                 "    bar: string;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotNullToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotNullToTsClassValidatorDecoratorConverterTest.java
@@ -18,7 +18,10 @@ class NotNullToTsClassValidatorDecoratorConverterTest extends ClassValidatorDeco
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @IsDefined({ message: CommonValidationMessages.IsDefined })\n" +
                 "    bar: string;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotNullToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/NotNullToTsClassValidatorDecoratorConverterTest.java
@@ -18,10 +18,7 @@ class NotNullToTsClassValidatorDecoratorConverterTest extends ClassValidatorDeco
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @IsDefined({ message: CommonValidationMessages.IsDefined })\n" +
                 "    bar: string;\n" +
@@ -32,6 +29,6 @@ class NotNullToTsClassValidatorDecoratorConverterTest extends ClassValidatorDeco
     static class Foo {
 
         @NotNull
-        private final String bar;
+        String bar;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/SizeToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/SizeToTsClassValidatorDecoratorConverterTest.java
@@ -4,6 +4,7 @@ import cz.habarta.typescript.generator.Input;
 import lombok.Value;
 import org.junit.jupiter.api.Test;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import java.util.List;
 
@@ -19,14 +20,16 @@ class SizeToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorat
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @MaxLength(2, { message: CommonValidationMessages.MaxLength(2) })\n" +
                 "    @MinLength(1, { message: CommonValidationMessages.MinLength(1) })\n" +
+                "    @IsOptional()\n" +
                 "    bar: string;\n" +
+                "    @IsNotEmpty({ message: CommonValidationMessages.IsNotEmpty })\n" +
+                "    @MaxLength(2, { message: CommonValidationMessages.MaxLength(2) })\n" +
+                "    @MinLength(1, { message: CommonValidationMessages.MinLength(1) })\n" +
+                "    notEmptyBar: string;\n" +
                 "    @ArrayMaxSize(4, { message: CommonValidationMessages.ArrayMaxSize(4) })\n" +
                 "    @ArrayMinSize(3, { message: CommonValidationMessages.ArrayMinSize(3) })\n" +
                 "    objects: any[];\n" +
@@ -37,9 +40,13 @@ class SizeToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorat
     static class Foo {
 
         @Size(min = 1, max = 2)
-        private final String bar;
+        String bar;
+
+        @NotEmpty
+        @Size(min = 1, max = 2)
+        String notEmptyBar;
 
         @Size(min = 3, max = 4)
-        private final List<Object> objects;
+        List<Object> objects;
     }
 }

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/SizeToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/SizeToTsClassValidatorDecoratorConverterTest.java
@@ -20,7 +20,10 @@ class SizeToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecorat
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @MaxLength(2, { message: CommonValidationMessages.MaxLength(2) })\n" +
                 "    @MinLength(1, { message: CommonValidationMessages.MinLength(1) })\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ValidToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ValidToTsClassValidatorDecoratorConverterTest.java
@@ -18,7 +18,10 @@ class ValidToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecora
 
         // then
         then(actual).isEqualTo(
-                "\n" + IMPORTS + "\n" +
+                "\n" +
+                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
+                "import { ValidateNested, IsOptional, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
+                "\n" +
                 "export class Foo {\n" +
                 "    @ValidateNested()\n" +
                 "    bar: any;\n" +

--- a/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ValidToTsClassValidatorDecoratorConverterTest.java
+++ b/infobip-typescript-generator-extension-api/src/test/java/com/infobip/typescript/validation/ValidToTsClassValidatorDecoratorConverterTest.java
@@ -18,10 +18,7 @@ class ValidToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecora
 
         // then
         then(actual).isEqualTo(
-                "\n" +
-                "import { CommonValidationMessages } from 'infobip-typescript-generator-common';\n" +
-                "import { ValidateNested, IsDefined, IsNotEmpty, MaxLength, MinLength, Max, Min, ArrayMaxSize, ArrayMinSize } from 'class-validator';\n" +
-                "\n" +
+                "\n" + IMPORTS + "\n" +
                 "export class Foo {\n" +
                 "    @ValidateNested()\n" +
                 "    bar: any;\n" +
@@ -32,6 +29,6 @@ class ValidToTsClassValidatorDecoratorConverterTest extends ClassValidatorDecora
     static class Foo {
 
         @Valid
-        private final Object bar;
+        Object bar;
     }
 }

--- a/infobip-typescript-generator-extension-model-showcase/pom.xml
+++ b/infobip-typescript-generator-extension-model-showcase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.infobip</groupId>
         <artifactId>infobip-typescript-generator-extension</artifactId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>infobip-typescript-generator-extension-model-showcase</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.infobip</groupId>
 	<artifactId>infobip-typescript-generator-extension</artifactId>
-	<version>1.0.6-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Infobip TypeScript Generator Extension</name>


### PR DESCRIPTION
- support for decorating non-hierarchical types with `class-transfomer`'s `@Type` as well (it is needed for `class-validator` to recognise all types correctly, which is mandatory when using the `forbidUnknownValues` flag as recommended by Snyk)
- support for decorating array/collection fields with `class-transfomer`'s `@Type` (for the same reason)
- adding the `@IsOptional` decorator where needed with `@MaxLength` / `@MinLength` (which by default don't accept null/undefined)